### PR TITLE
allow user-input path to teams.yaml

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -5,6 +5,9 @@ inputs:
   token:
     description: "A Github personal authentication token"
     required: true
+  yamlpath:
+    description: "Path to the teams.yaml file (if missing, assume it's in repo root)"
+    required: false
 
 runs:
   using: "composite"

--- a/action.yaml
+++ b/action.yaml
@@ -23,4 +23,4 @@ runs:
       shell: bash
       run: >-
         python -m pip install pyyaml requests;
-        python ${{ github.action_path }}/sync-teams-to-gh.py -o ${{ github.repository_owner }} -p ${YAML_PATH:=teams.yaml} -m >> $GITHUB_STEP_SUMMARY
+        python ${{ github.action_path }}/sync-teams-to-gh.py -o ${{ github.repository_owner }} -p ${YAML_PATH:-teams.yaml} -m >> $GITHUB_STEP_SUMMARY

--- a/action.yaml
+++ b/action.yaml
@@ -13,10 +13,17 @@ runs:
       uses: actions/setup-python@v6
       with:
         python-version: "3.11"
+    - name: Check for custom path
+      env:
+        YAML_PATH: ${{ inputs.yamlpath }}
+      shell: bash
+      run: >-
+        YAML_PATH:=teams.yaml
+        echo "YAML_PATH=$YAML_PATH" | tee -a $GITHUB_ENV
     - name: Sync teams
       env:
         GH_TOKEN: ${{ inputs.token }}
       shell: bash
       run: >-
         python -m pip install pyyaml requests;
-        python ${{ github.action_path }}/sync-teams-to-gh.py -o ${{ github.repository_owner }} -m >> $GITHUB_STEP_SUMMARY
+        python ${{ github.action_path }}/sync-teams-to-gh.py -o ${{ github.repository_owner }} -p ${{ github.env.YAML_PATH }} -m >> $GITHUB_STEP_SUMMARY

--- a/action.yaml
+++ b/action.yaml
@@ -8,6 +8,7 @@ inputs:
   yamlpath:
     description: "Path to the teams.yaml file (if missing, assume it's in repo root)"
     required: false
+    default: teams.yaml
 
 runs:
   using: "composite"
@@ -23,4 +24,4 @@ runs:
       shell: bash
       run: >-
         python -m pip install pyyaml requests;
-        python ${{ github.action_path }}/sync-teams-to-gh.py -o ${{ github.repository_owner }} -p ${YAML_PATH:-teams.yaml} -m | tee -a $GITHUB_STEP_SUMMARY
+        python ${{ github.action_path }}/sync-teams-to-gh.py -o ${{ github.repository_owner }} -p $YAML_PATH -m | tee -a $GITHUB_STEP_SUMMARY

--- a/action.yaml
+++ b/action.yaml
@@ -6,7 +6,7 @@ inputs:
     description: "A Github personal authentication token"
     required: true
   yamlpath:
-    description: "Path to the teams.yaml file (if missing, assume it's in repo root)"
+    description: "Location of the teams.yaml file (if unspecified, defaults to `./teams.yaml`—at the root of the repo)"
     required: false
     default: teams.yaml
 

--- a/action.yaml
+++ b/action.yaml
@@ -13,17 +13,11 @@ runs:
       uses: actions/setup-python@v6
       with:
         python-version: "3.11"
-    - name: Check for custom path
-      env:
-        YAML_PATH: ${{ inputs.yamlpath }}
-      shell: bash
-      run: >-
-        YAML_PATH:=teams.yaml
-        echo "YAML_PATH=$YAML_PATH" | tee -a $GITHUB_ENV
     - name: Sync teams
       env:
         GH_TOKEN: ${{ inputs.token }}
+        YAML_PATH: ${{ inputs.yamlpath }}
       shell: bash
       run: >-
         python -m pip install pyyaml requests;
-        python ${{ github.action_path }}/sync-teams-to-gh.py -o ${{ github.repository_owner }} -p ${{ github.env.YAML_PATH }} -m >> $GITHUB_STEP_SUMMARY
+        python ${{ github.action_path }}/sync-teams-to-gh.py -o ${{ github.repository_owner }} -p ${YAML_PATH:=teams.yaml} -m >> $GITHUB_STEP_SUMMARY

--- a/action.yaml
+++ b/action.yaml
@@ -23,4 +23,4 @@ runs:
       shell: bash
       run: >-
         python -m pip install pyyaml requests;
-        python ${{ github.action_path }}/sync-teams-to-gh.py -o ${{ github.repository_owner }} -p ${YAML_PATH:-teams.yaml} -m >> $GITHUB_STEP_SUMMARY
+        python ${{ github.action_path }}/sync-teams-to-gh.py -o ${{ github.repository_owner }} -p ${YAML_PATH:-teams.yaml} -m | tee -a $GITHUB_STEP_SUMMARY

--- a/sync-teams-to-gh.py
+++ b/sync-teams-to-gh.py
@@ -31,6 +31,9 @@ parser.add_argument(
 parser.add_argument(
     "-m", "--markdown", action="store_true", help="Print output in Markdown format"
 )
+parser.add_argument(
+    "-p", "--path", action="store_true", help="path to the teams.yaml file"
+)
 parser.add_argument("-o", "--org", type=str, required=True)
 
 args = parser.parse_args()
@@ -179,7 +182,9 @@ if args.download:
     sys.exit()
 
 
-config = yaml.load(open("teams.yaml"), Loader=yaml.SafeLoader)
+path = args.path or "teams.yaml"
+
+config = yaml.load(open(path), Loader=yaml.SafeLoader)
 config = {team["name"]: team for team in config}
 
 

--- a/sync-teams-to-gh.py
+++ b/sync-teams-to-gh.py
@@ -31,7 +31,9 @@ parser.add_argument(
 parser.add_argument(
     "-m", "--markdown", action="store_true", help="Print output in Markdown format"
 )
-parser.add_argument("-p", "--path", help="path to the teams.yaml file")
+parser.add_argument(
+    "-p", "--path", help="path to the teams.yaml file", default="teams.yaml"
+)
 parser.add_argument("-o", "--org", type=str, required=True)
 
 args = parser.parse_args()
@@ -180,9 +182,7 @@ if args.download:
     sys.exit()
 
 
-path = args.path or "teams.yaml"
-
-config = yaml.load(open(path), Loader=yaml.SafeLoader)
+config = yaml.load(open(args.path), Loader=yaml.SafeLoader)
 config = {team["name"]: team for team in config}
 
 

--- a/sync-teams-to-gh.py
+++ b/sync-teams-to-gh.py
@@ -32,7 +32,7 @@ parser.add_argument(
     "-m", "--markdown", action="store_true", help="Print output in Markdown format"
 )
 parser.add_argument(
-    "-p", "--path", help="path to the teams.yaml file", default="teams.yaml"
+    "-p", "--path", help="Path to the teams.yaml file", default="teams.yaml"
 )
 parser.add_argument("-o", "--org", type=str, required=True)
 

--- a/sync-teams-to-gh.py
+++ b/sync-teams-to-gh.py
@@ -31,9 +31,7 @@ parser.add_argument(
 parser.add_argument(
     "-m", "--markdown", action="store_true", help="Print output in Markdown format"
 )
-parser.add_argument(
-    "-p", "--path", action="store_true", help="path to the teams.yaml file"
-)
+parser.add_argument("-p", "--path", help="path to the teams.yaml file")
 parser.add_argument("-o", "--org", type=str, required=True)
 
 args = parser.parse_args()


### PR DESCRIPTION
this PR allows users to pass in a custom path to the `teams.yaml` file. We wanted this for MNE-Python because we're not storing `teams.yaml` in a dedicated repo (there will be other admin stuff in there) so we don't want the teams file at repo root.